### PR TITLE
Remove table from database before scraping

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -80,6 +80,6 @@ def scrape_person(person, positions)
   ScraperWiki.save_sqlite(%i(id), data)
 end
 
-ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
+ScraperWiki.sqliteexecute('DROP TABLE data') rescue nil
 positions = get_positions('http://www.shineyoureye.org/media_root/popolo_json/memberships.json')
 scrape_json('http://www.shineyoureye.org/media_root/popolo_json/persons.json', positions)


### PR DESCRIPTION
SqliteMagic creates a unique index at CREATE TABLE time. This means that if the unique index arguments of ScraperWiki.save_sqlite change, we need to create a new table to ensure the db reflects the change. Part of: https://github.com/everypolitician/everypolitician/issues/593